### PR TITLE
Fix (some) resurrected followers + small refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -481,3 +481,6 @@ thunderstore/
 releases/
 /lib/
 /build/
+
+# local diff patches
+/patches/

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ TARGET_FRAMEWORK := netstandard2.1
 
 MOD_AUTHOR := f4iTh
 MOD_NAME := ShowFollowerJobTitles
-MOD_VERSION := 1.1.0
+MOD_VERSION := 1.1.1
 
 # TODO: figure out better way to handle; issue about system path env var
 7Z := C:\Program Files\7-Zip\7z.exe

--- a/ShowFollowerJobTitles.csproj
+++ b/ShowFollowerJobTitles.csproj
@@ -6,7 +6,7 @@
     <RootNamespace>ShowFollowerJobTitles</RootNamespace>
     <TargetFramework>netstandard2.1</TargetFramework>
     <Description>A mod that displays a follower's current job with its respective icon.</Description>
-    <Version>1.1.0</Version>
+    <Version>1.1.1</Version>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
     <RestoreAdditionalProjectSources>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,14 +2,12 @@
 
 ## 1.1.0
 
-*I probably should've used 1.1 for the Woolhaven update but I forgot.*
-
-- Added fallback for role that do not have icons in the font (ex. some of the new DLC roles like logistics)
-  so they instead use the icon for their command
+- Added fallback icons for roles (i.e., logistics) that do not have icons in the font
+  so they instead use the icon for their command (thanks [nicopop](https://github.com/nicopop)!)
 
 ## 1.0.3
 
-- Fixed compatibility with the Woolhaven update
+- Fixed compatibility with the Woolhaven update (thanks [nicopop](https://github.com/nicopop)!)
 
 ## 1.0.2
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Update notes
 
+## 1.1.1
+
+- Fixed role icons not showing up for resurrected followers
+
 ## 1.1.0
 
 - Added fallback icons for roles (i.e., logistics) that do not have icons in the font

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "ShowFollowerJobTitles",
   "description": "A mod that displays a follower's current job with its respective icon.",
-  "version_number": "1.1.0",
+  "version_number": "1.1.1",
   "dependencies": [
     "BepInEx-BepInExPack_CultOfTheLamb-5.4.21"
   ],

--- a/src/Common/Extensions/FollowerCommandsExtensions.cs
+++ b/src/Common/Extensions/FollowerCommandsExtensions.cs
@@ -1,9 +1,12 @@
-﻿namespace ShowFollowerJobTitles.Common.Extensions;
+﻿using System;
+
+namespace ShowFollowerJobTitles.Common.Extensions;
 
 /// <summary>A class containing extension methods for the <see cref="FollowerCommands" /> enum.</summary>
 public static class FollowerCommandsExtensions {
   /// <summary>Whether the <see cref="FollowerCommands" /> is a <see cref="FollowerRole" /> command.</summary>
   /// <param name="followerCommand">The follower command.</param>
+  /// <returns><c>true</c> if <paramref name="followerCommand"/> results in a valid <see cref="FollowerRole"/>, otherwise <c>false</c></returns>
   public static bool IsFollowerRoleCommand(this FollowerCommands followerCommand) {
     return followerCommand
       is FollowerCommands.WorshipAtShrine
@@ -28,9 +31,11 @@ public static class FollowerCommandsExtensions {
 
   /// <summary>Gets a <see cref="FollowerRole" /> based on the value of <see cref="FollowerCommands" />.</summary>
   /// <param name="followerCommand">The follower command.</param>
+  /// <exception cref="ArgumentOutOfRangeException"><paramref name="followerCommand"/> of type <see cref="FollowerCommands"/> does not result in a valid <see cref="FollowerRole"/></exception>
   public static FollowerRole FollowerCommandToRole(this FollowerCommands followerCommand) {
     return followerCommand switch {
       FollowerCommands.WorshipAtShrine => FollowerRole.Worshipper,
+      // => FollowerRole.Worker,
       FollowerCommands.CutTrees => FollowerRole.Lumberjack,
       FollowerCommands.Farmer_2 => FollowerRole.Farmer,
       FollowerCommands.Study => FollowerRole.Monk,
@@ -40,6 +45,7 @@ public static class FollowerCommandsExtensions {
       FollowerCommands.Cook_2 => FollowerRole.Chef,
       FollowerCommands.Janitor_2 => FollowerRole.Janitor,
       FollowerCommands.Refiner_2 => FollowerRole.Refiner,
+      // => FollowerRole.Berries,
       FollowerCommands.Undertaker => FollowerRole.Undertaker,
       FollowerCommands.Brew => FollowerRole.Bartender,
       FollowerCommands.Medic => FollowerRole.Medic,
@@ -48,33 +54,8 @@ public static class FollowerCommandsExtensions {
       FollowerCommands.Handyman => FollowerRole.Handyman,
       FollowerCommands.TraitManipulator => FollowerRole.TraitManipulator,
       FollowerCommands.MineRotstone => FollowerRole.RotstoneMiner,
-      var _ => FollowerRole.Worker
-    };
-  }
-
-  /// <summary>Gets a <see cref="FollowerCommands" /> based on the value of <see cref="FollowerRole" />.</summary>
-  /// <param name="followerRole">The follower command.</param>
-  public static FollowerCommands FollowerRoleToCommand(FollowerRole followerRole) {
-    return followerRole switch {
-      FollowerRole.Worshipper => FollowerCommands.WorshipAtShrine,
-      FollowerRole.Lumberjack => FollowerCommands.CutTrees,
-      FollowerRole.Farmer => FollowerCommands.Farmer_2,
-      FollowerRole.Monk => FollowerCommands.Study,
-      FollowerRole.StoneMiner => FollowerCommands.ClearRubble,
-      FollowerRole.Builder => FollowerCommands.Build,
-      FollowerRole.Forager => FollowerCommands.ForageBerries,
-      FollowerRole.Chef => FollowerCommands.Cook_2,
-      FollowerRole.Janitor => FollowerCommands.Janitor_2,
-      FollowerRole.Refiner => FollowerCommands.Refiner_2,
-      FollowerRole.Undertaker => FollowerCommands.Undertaker,
-      FollowerRole.Bartender => FollowerCommands.Brew,
-      FollowerRole.Medic => FollowerCommands.Medic,
-      FollowerRole.Rancher => FollowerCommands.Rancher,
-      FollowerRole.Logistics => FollowerCommands.Logistics,
-      FollowerRole.Handyman => FollowerCommands.Handyman,
-      FollowerRole.TraitManipulator => FollowerCommands.TraitManipulator,
-      FollowerRole.RotstoneMiner => FollowerCommands.MineRotstone,
-      var _ => FollowerCommands.None
+      // var _ => FollowerRole.Worker
+      var _ => throw new ArgumentOutOfRangeException(nameof(followerCommand), followerCommand, "Given follower command does not return a valid FollowerRole")
     };
   }
 }

--- a/src/Common/Extensions/FollowerRoleExtensions.cs
+++ b/src/Common/Extensions/FollowerRoleExtensions.cs
@@ -1,0 +1,35 @@
+﻿using System;
+
+namespace ShowFollowerJobTitles.Common.Extensions;
+
+public static class FollowerRoleExtensions {
+  /// <summary>Gets a <see cref="FollowerCommands" /> based on the value of <see cref="FollowerRole" />.</summary>
+  /// <param name="followerRole">The follower command.</param>
+  /// <exception cref="ArgumentOutOfRangeException"><paramref name="followerRole"/> is not a valid <see cref="FollowerRole" />.</exception>
+  public static FollowerCommands FollowerRoleToCommand(this FollowerRole followerRole) {
+    return followerRole switch {
+      FollowerRole.Worshipper => FollowerCommands.WorshipAtShrine,
+      // FollowerRole.Worker =>
+      FollowerRole.Lumberjack => FollowerCommands.CutTrees,
+      FollowerRole.Farmer => FollowerCommands.Farmer_2,
+      FollowerRole.Monk => FollowerCommands.Study,
+      FollowerRole.StoneMiner => FollowerCommands.ClearRubble,
+      FollowerRole.Builder => FollowerCommands.Build,
+      FollowerRole.Forager => FollowerCommands.ForageBerries,
+      FollowerRole.Chef => FollowerCommands.Cook_2,
+      FollowerRole.Janitor => FollowerCommands.Janitor_2,
+      FollowerRole.Refiner => FollowerCommands.Refiner_2,
+      // FollowerRole.Berries =>
+      FollowerRole.Undertaker => FollowerCommands.Undertaker,
+      FollowerRole.Bartender => FollowerCommands.Brew,
+      FollowerRole.Medic => FollowerCommands.Medic,
+      FollowerRole.Rancher => FollowerCommands.Rancher,
+      FollowerRole.Logistics => FollowerCommands.Logistics,
+      FollowerRole.Handyman => FollowerCommands.Handyman,
+      FollowerRole.TraitManipulator => FollowerCommands.TraitManipulator,
+      FollowerRole.RotstoneMiner => FollowerCommands.MineRotstone,
+      // var _ => FollowerCommands.None
+      var _ => throw new ArgumentOutOfRangeException(nameof(followerRole), followerRole, "Given follower role does not return a valid FollowerCommands")
+    };
+  }
+}

--- a/src/Common/Extensions/FontImageNamesExtensions.cs
+++ b/src/Common/Extensions/FontImageNamesExtensions.cs
@@ -4,23 +4,17 @@ namespace ShowFollowerJobTitles.Common.Extensions;
 
 /// <summary>A class containing extension methods for the <see cref="FontImageNames" /> class</summary>
 public static class FontImageNamesExtensions {
-  /// <summary>
-  ///   Get a roleIcon string based on on the value of <see cref="FollowerRole" />.
-  ///   Will return empty string if no icons are found
-  /// </summary>
+  /// <summary>Get a roleIcon string based on the value of <see cref="FollowerRole" /></summary>
   /// <param name="followerRole">the Role of the follower</param>
-  /// <returns></returns>
-  public static string GetIconForRole(FollowerRole followerRole) {
-    string roleIcon = FontImageNames.IconForRole(followerRole);
-    if (string.IsNullOrWhiteSpace(roleIcon))
-      try {
-        roleIcon = FontImageNames.IconForCommand(FollowerCommandsExtensions.FollowerRoleToCommand(followerRole));
-      }
-      catch (ArgumentOutOfRangeException) {
-        // Fallback also failed so keep empty,
-        // I'll maybe try later to add support for custom role here if possible
-      }
+  /// <returns>Icon for the given follower role; empty string if not found</returns>
+  public static string GetIconForRole(this FollowerRole followerRole) {
+    if (followerRole is FollowerRole.Worker or FollowerRole.Berries) // no icons available; TODO: use alternative/custom icons?
+      return "";
 
-    return roleIcon;
+    string roleIcon = FontImageNames.IconForRole(followerRole);
+    if (!string.IsNullOrWhiteSpace(roleIcon))
+      return roleIcon;
+
+    return FontImageNames.IconForCommand(followerRole.FollowerRoleToCommand()) ?? "";
   }
 }

--- a/src/Common/Patches/FollowerInformationBoxPatches.cs
+++ b/src/Common/Patches/FollowerInformationBoxPatches.cs
@@ -20,7 +20,7 @@ public class FollowerInformationBoxPatches {
     if (__instance.FollowerRole == null || __instance.FollowerInfo.OldAge || __instance.FollowerInfo.HasThought(Thought.OldAge) || __instance.FollowerInfo.CursedState == Thought.Child)
       return;
 
-    string roleIcon = FontImageNamesExtensions.GetIconForRole(__instance.followBrain?.Info.FollowerRole ?? __instance.FollowerInfo.FollowerRole);
+    string roleIcon = (__instance.followBrain?.Info.FollowerRole ?? __instance.FollowerInfo.FollowerRole).GetIconForRole();
     if (string.IsNullOrWhiteSpace(roleIcon))
       return;
 

--- a/src/Common/Patches/NotificationFollowerPatches.cs
+++ b/src/Common/Patches/NotificationFollowerPatches.cs
@@ -32,7 +32,7 @@ public class NotificationFollowerPatches {
     if (notificationType != NotificationCentre.NotificationType.BecomeOld || description == null)
       return;
 
-    string roleIcon = FontImageNamesExtensions.GetIconForRole(followerInfo.FollowerRole);
+    string roleIcon = followerInfo.FollowerRole.GetIconForRole();
     if (string.IsNullOrWhiteSpace(roleIcon))
       return;
 

--- a/src/Common/Patches/UIFollowerNamePatches.cs
+++ b/src/Common/Patches/UIFollowerNamePatches.cs
@@ -26,7 +26,7 @@ public class UIFollowerNamePatches {
 
     TMP_Text nameText = (TMP_Text)nameTextFieldInfo.GetValue(__instance);
     Follower follower = (Follower)followerFieldInfo.GetValue(__instance);
-    string roleIcon = FontImageNamesExtensions.GetIconForRole(follower.Brain.Info.FollowerRole);
+    string roleIcon = follower.Brain.Info.FollowerRole.GetIconForRole();
     int roleIconIndex = nameText.text.IndexOf(roleIcon, StringComparison.Ordinal);
 
     // do not display role for old people or babies

--- a/src/Common/Patches/UIFollowerNamePatches.cs
+++ b/src/Common/Patches/UIFollowerNamePatches.cs
@@ -30,7 +30,7 @@ public class UIFollowerNamePatches {
     int roleIconIndex = nameText.text.IndexOf(roleIcon, StringComparison.Ordinal);
 
     // do not display role for old people or babies
-    if (follower.Brain.Info.OldAge || follower.Brain.HasThought(Thought.OldAge) || follower.Brain.Info.CursedState == Thought.Child) {
+    if (follower.Brain.Info.CursedState == Thought.OldAge || follower.Brain.HasThought(Thought.OldAge) || follower.Brain.Info.CursedState == Thought.Child) {
       // remove role string after becoming old
       if (roleIconIndex > 0)
         nameText.text = nameText.text.Remove(roleIconIndex, roleIcon.Length - 1);

--- a/src/Common/Patches/UIFollowerWheelInteractionItemPatches.cs
+++ b/src/Common/Patches/UIFollowerWheelInteractionItemPatches.cs
@@ -11,7 +11,7 @@ namespace ShowFollowerJobTitles.Common.Patches;
 /// <summary>A class containing patches for <see cref="UIFollowerWheelInteractionItem" /></summary>
 [HarmonyPatch]
 public class UIFollowerWheelInteractionItemPatches {
-  /// <summary>The patch method for <see cref="UIFollowerWheelInteractionItem.Configure" />.</summary>
+  /// <summary>The patch method for <see cref="UIFollowerWheelInteractionItem.Configure(Follower, CommandItem)" />.</summary>
   /// <param name="__instance">The <see cref="UIFollowerWheelInteractionItem" /> instance.</param>
   /// <param name="follower">The follower.</param>
   /// <param name="commandItem">The command item.</param>
@@ -42,7 +42,7 @@ public class UIFollowerWheelInteractionItemPatches {
       return;
     }
 
-    // handle unavailable roles 
+    // handle unavailable roles
     if (!commandItem.IsAvailable(follower)) {
       // builder seems to work differently; add +1 count to unselectable roles other than builder
       titleFieldInfo.SetValue(__instance, $"{title} ({jobCount}{(followerRole == FollowerRole.Builder ? "" : " + 1")})");

--- a/src/Plugin.cs
+++ b/src/Plugin.cs
@@ -1,4 +1,5 @@
-﻿using BepInEx;
+﻿using System.Reflection;
+using BepInEx;
 using BepInEx.Logging;
 using HarmonyLib;
 
@@ -21,6 +22,9 @@ public class Plugin : BaseUnityPlugin {
   /// <inheritdoc cref="Plugin.OnEnable" />
   private void OnEnable() {
     this._harmony.PatchAll();
+
+    foreach (MethodBase method in this._harmony.GetPatchedMethods())
+      StaticLogger.LogInfo($"patched {method.ReflectedType?.Name}::{method.Name}");
   }
 
   /// <inheritdoc cref="Plugin.OnDisable" />

--- a/src/Plugin.cs
+++ b/src/Plugin.cs
@@ -6,7 +6,7 @@ using HarmonyLib;
 namespace ShowFollowerJobTitles;
 
 /// <summary>The plugin entry point.</summary>
-[BepInPlugin("com.f4iTh.COTL.ShowFollowerJobTitles", "Show Follower Job Titles", "1.1.0")]
+[BepInPlugin("com.f4iTh.COTL.ShowFollowerJobTitles", "Show Follower Job Titles", "1.1.1")]
 public class Plugin : BaseUnityPlugin {
   /// <summary>A static logger instance that can be used across the entire project.</summary>
   internal static ManualLogSource StaticLogger;


### PR DESCRIPTION
## Features
- Fixed role icons not showing up for (some) resurrected followers
    - Primarily resurrected old followers; seemed to work fine otherwise (not necessarily 100% foolproof fix)
- Added credits for Woolhaven compatibility update + fallback role icon(s)
- Small extension method refactor(s) + documentation "fixes"

---
fixes #5 